### PR TITLE
feat(cli): CTI batching flags + hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,22 @@ htmlcov/
 .coverage
 coverage.xml
 
+# Editors / local debug artifacts
+.vscode/
+.debug/
+
+# Generated processed reports and test outputs
+data/processed-test/*
+!data/processed-test/.gitkeep
+data/processed/reports/*
+!data/processed/reports/.gitkeep
+
+# Large media under docs (keep small images)
+docs/*.mp4
+
+# Windows ADS metadata (e.g., from WSL copies)
+*:Zone.Identifier
+
 # Notebooks
 *.ipynb_checkpoints/
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -362,6 +362,8 @@ def main(argv: List[str] | None = None) -> int:
     # CTI request controls
     parser.add_argument("--cti-scope", choices=["suspicious", "all"], default="suspicious", help="Which IPs to look up for CTI")
     parser.add_argument("--cti-max", type=int, default=100, help="Max CTI lookups (0=unlimited)")
+    parser.add_argument("--cti-batch-size", type=int, default=0, help="Batch size for CTI lookups (0=disabled)")
+    parser.add_argument("--cti-batch-pause", type=float, default=0.0, help="Pause seconds between CTI batches")
     args = parser.parse_args(argv)
 
     # Configure console color policy

--- a/src/parsers/ua_analysis.py
+++ b/src/parsers/ua_analysis.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 
 SUSPICIOUS_AGENTS = [
@@ -19,12 +19,12 @@ SUSPICIOUS_AGENTS = [
 ]
 
 
-def detect_suspicious_user_agent(ua: str | None) -> Tuple[bool, str | None]:
+def detect_suspicious_user_agent(ua: Optional[str], patterns: Optional[List[str]] = None) -> Tuple[bool, Optional[str]]:
     if not ua:
         return False, None
     ua_l = ua.lower()
-    for pat in SUSPICIOUS_AGENTS:
+    pats = patterns if patterns else SUSPICIOUS_AGENTS
+    for pat in pats:
         if re.search(pat, ua_l):
             return True, pat
     return False, None
-


### PR DESCRIPTION
Summary
- Add CLI flags `--cti-batch-size` and `--cti-batch-pause` to support resilient, budget-aware CTI lookups.
- Keep existing offline‑first behavior; LLM/CTI remain optional and gated.
- No large binaries or debug artifacts added to history.

Rationale
- Batching + pause helps avoid rate limits and enables incremental cache flushing when processing many IPs.
- Aligns with repo guidelines: suspicious‑first CTI, capped queries, strong cache, and graceful degradation.

Details
- CLI: `src/cli.py` exposes two new CTI flags. The pipeline already passes these through to `cti_for_ips`.
- Env/Docs: `.env.example` previously sanitized (no real-looking keys). README/docs already mention batching; CLI now matches docs.
- Tests: existing suite still green locally (24 passed). No network is required.

Usage Examples
- `python -m src.cli data/raw/big.log --out data/processed --llm-group-by ip --group-window 60 --llm-gate-4xx 5 --llm-sample 200 --cti-scope suspicious --cti-max 200 --cti-batch-size 50 --cti-batch-pause 1.5 --color never`
- Strictly offline: `python -m src.cli data/raw/big.log --out data/processed --no-llm --no-cti --no-reports`

Checklist
- [x] No secrets committed
- [x] No large files committed
- [x] Tests pass locally
- [x] Backwards compatible (flags default to no-op)
